### PR TITLE
Add Conserved Primer Design skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Skill libraries and tool collections specifically targeting genomics, bioinforma
 - [bioSkills](https://github.com/GPTomics/bioSkills)
   - **Description:** SKILL.md files for bioinformatics with Claude Code, covering end-to-end pipelines like RNA-seq, variants, ChIP-seq, scRNA-seq, spatial, Hi-C, proteomics, microbiome, CRISPR, metabolomics, multi-omics, immunotherapy, outbreak analysis, and Mendelian randomization tools.
   - **Developers:** GPTomics ([gptomics.com](https://www.gptomics.com)), an independent research lab working at the bioinformatics/AI intersection.
+- [Conserved Primer Design](https://github.com/KevinSpringer1/conserved-primer-design)
+  - **Description:** Agent skill package for calling the VirusPrimerPro website Agent API to run conserved-region, primer-site, PhyloGuide, and tNGS amplicon panel workflows. Includes API helpers, NCBI/MAFFT preparation, taxonomy and reference curation, specificity screening, primer wet-lab QC, panel pooling, validation reports, and compatibility notes for Codex, Claude Code, VS Code/Copilot, and generic agents.
+  - **Developers:** KevinSpringer1.
 - [Clair-skills](https://github.com/HKU-BAL/Clair-skills)
   - **Description:** Agent skill for the Clair suite of variant callers (Clair3, ClairS, Clair3-RNA, Clair-Mosaic); provides intelligent model selection, command generation, and troubleshooting for germline, somatic, mosaic, and RNA-seq variant calling from long-read and short-read sequencing data.
   - **Developers:** Ruibang Luo's BioAI Lab at the University of Hong Kong (HKU-BAL).


### PR DESCRIPTION
## Summary

Adds Conserved Primer Design, an Agent Skill package for using the VirusPrimerPro website Agent API in conserved primer and tNGS amplicon panel workflows.

## Why it belongs

- Directly relevant to genomics and bioinformatics agent workflows.
- Public MIT-licensed repository with README, AGENTS.md, CLAUDE.md, VS Code/Copilot instructions, task-specific SKILL.md files, helper scripts, and smoke-test fixtures.
- Covers VirusPrimerPro API submission/polling/artifacts plus NCBI/MAFFT input preparation, taxonomy/reference curation, specificity screening, primer QC, panel pooling, and validation reports.

## Verification

- Link is public and accessible: https://github.com/KevinSpringer1/conserved-primer-design
- Repository includes an MIT license.
- Local smoke tests passed in the submitted repository before publication.